### PR TITLE
Refactor Makefile to use echo instead of sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ compile:
 	make compile_alu
 	sv2v -I src/* -w build/gpu.v
 	cat build/alu.v >> build/gpu.v
-	sed -i '' '1s/^/`timescale 1ns\/1ns\n/' build/gpu.v
+	echo '`timescale 1ns/1ns' > build/temp.v
+	cat build/gpu.v >> build/temp.v
+	mv build/temp.v build/gpu.v
 
 compile_%:
 	sv2v -w build/$*.v src/$*.sv


### PR DESCRIPTION
This pull request updates the Makefile to replace sed with echo for prepending the "`timescale 1ns/1ns" directive to the top of the build/gpu.v file. This change simplifies the command and enhances portability across different operating systems.