### PR TITLE
Couple of changes to get this running on ubuntu 2204 with iverilog 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test_%:
 	MODULE=test.test_$* vvp -M $$(cocotb-config --prefix)/cocotb/libs -m libcocotbvpi_icarus build/sim.vvp
 
 compile:
+	mkdir -p build
 	make compile_alu
 	sv2v -I src/* -w build/gpu.v
 	echo "" >> build/gpu.v

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ RET                            ; end of kernel
 
 # Simulation
 
-tiny-gpu is setup to simulate the execution of both of the above kernels. Before simulating, you'll need to install [iverilog](https://steveicarus.github.io/iverilog/usage/installation.html) and [cocotb](https://docs.cocotb.org/en/stable/install.html).
+tiny-gpu is setup to simulate the execution of both of the above kernels. Before simulating, you'll need to install [iverilog](https://steveicarus.github.io/iverilog/usage/installation.html), [cocotb](https://docs.cocotb.org/en/stable/install.html) and [sv2v](https://github.com/zachjs/sv2v).
 
 Once you've installed the pre-requisites, you can run the kernel simulations with `make test_matadd` and `make test_matmul`.
 

--- a/src/alu.sv
+++ b/src/alu.sv
@@ -11,13 +11,13 @@ module alu (
     input wire reset,
     input wire enable, // If current block has less threads then block size, some ALUs will be inactive
 
-    input reg [2:0] core_state,
+    input [2:0] core_state,
 
-    input reg [1:0] decoded_alu_arithmetic_mux,
-    input reg decoded_alu_output_mux,
+    input [1:0] decoded_alu_arithmetic_mux,
+    input decoded_alu_output_mux,
 
-    input reg [7:0] rs,
-    input reg [7:0] rt,
+    input [7:0] rs,
+    input [7:0] rt,
     output wire [7:0] alu_out
 );
     localparam ADD = 2'b00,

--- a/src/controller.sv
+++ b/src/controller.sv
@@ -16,24 +16,24 @@ module controller #(
     input wire reset,
 
     // Consumer Interface (Fetchers / LSUs)
-    input reg [NUM_CONSUMERS-1:0] consumer_read_valid,
-    input reg [ADDR_BITS-1:0] consumer_read_address [NUM_CONSUMERS-1:0],
+    input [NUM_CONSUMERS-1:0] consumer_read_valid,
+    input [ADDR_BITS-1:0] consumer_read_address [NUM_CONSUMERS-1:0],
     output reg [NUM_CONSUMERS-1:0] consumer_read_ready,
     output reg [DATA_BITS-1:0] consumer_read_data [NUM_CONSUMERS-1:0],
-    input reg [NUM_CONSUMERS-1:0] consumer_write_valid,
-    input reg [ADDR_BITS-1:0] consumer_write_address [NUM_CONSUMERS-1:0],
-    input reg [DATA_BITS-1:0] consumer_write_data [NUM_CONSUMERS-1:0],
+    input [NUM_CONSUMERS-1:0] consumer_write_valid,
+    input [ADDR_BITS-1:0] consumer_write_address [NUM_CONSUMERS-1:0],
+    input [DATA_BITS-1:0] consumer_write_data [NUM_CONSUMERS-1:0],
     output reg [NUM_CONSUMERS-1:0] consumer_write_ready,
 
     // Memory Interface (Data / Program)
     output reg [NUM_CHANNELS-1:0] mem_read_valid,
     output reg [ADDR_BITS-1:0] mem_read_address [NUM_CHANNELS-1:0],
-    input reg [NUM_CHANNELS-1:0] mem_read_ready,
-    input reg [DATA_BITS-1:0] mem_read_data [NUM_CHANNELS-1:0],
+    input [NUM_CHANNELS-1:0] mem_read_ready,
+    input [DATA_BITS-1:0] mem_read_data [NUM_CHANNELS-1:0],
     output reg [NUM_CHANNELS-1:0] mem_write_valid,
     output reg [ADDR_BITS-1:0] mem_write_address [NUM_CHANNELS-1:0],
     output reg [DATA_BITS-1:0] mem_write_data [NUM_CHANNELS-1:0],
-    input reg [NUM_CHANNELS-1:0] mem_write_ready
+    input [NUM_CHANNELS-1:0] mem_write_ready
 );
     localparam IDLE = 3'b000, 
         READ_WAITING = 3'b010, 

--- a/src/core.sv
+++ b/src/core.sv
@@ -26,18 +26,18 @@ module core #(
     // Program Memory
     output reg program_mem_read_valid,
     output reg [PROGRAM_MEM_ADDR_BITS-1:0] program_mem_read_address,
-    input reg program_mem_read_ready,
-    input reg [PROGRAM_MEM_DATA_BITS-1:0] program_mem_read_data,
+    input program_mem_read_ready,
+    input [PROGRAM_MEM_DATA_BITS-1:0] program_mem_read_data,
 
     // Data Memory
     output reg [THREADS_PER_BLOCK-1:0] data_mem_read_valid,
     output reg [DATA_MEM_ADDR_BITS-1:0] data_mem_read_address [THREADS_PER_BLOCK-1:0],
-    input reg [THREADS_PER_BLOCK-1:0] data_mem_read_ready,
-    input reg [DATA_MEM_DATA_BITS-1:0] data_mem_read_data [THREADS_PER_BLOCK-1:0],
+    input [THREADS_PER_BLOCK-1:0] data_mem_read_ready,
+    input [DATA_MEM_DATA_BITS-1:0] data_mem_read_data [THREADS_PER_BLOCK-1:0],
     output reg [THREADS_PER_BLOCK-1:0] data_mem_write_valid,
     output reg [DATA_MEM_ADDR_BITS-1:0] data_mem_write_address [THREADS_PER_BLOCK-1:0],
     output reg [DATA_MEM_DATA_BITS-1:0] data_mem_write_data [THREADS_PER_BLOCK-1:0],
-    input reg [THREADS_PER_BLOCK-1:0] data_mem_write_ready
+    input [THREADS_PER_BLOCK-1:0] data_mem_write_ready
 );
     // State
     reg [2:0] core_state;

--- a/src/decoder.sv
+++ b/src/decoder.sv
@@ -8,8 +8,8 @@ module decoder (
     input wire clk,
     input wire reset,
 
-    input reg [2:0] core_state,
-    input reg [15:0] instruction,
+    input [2:0] core_state,
+    input [15:0] instruction,
     
     // Instruction Signals
     output reg [3:0] decoded_rd_address,

--- a/src/dispatch.sv
+++ b/src/dispatch.sv
@@ -17,7 +17,7 @@ module dispatch #(
     input wire [7:0] thread_count,
 
     // Core States
-    input reg [NUM_CORES-1:0] core_done,
+    input [NUM_CORES-1:0] core_done,
     output reg [NUM_CORES-1:0] core_start,
     output reg [NUM_CORES-1:0] core_reset,
     output reg [7:0] core_block_id [NUM_CORES-1:0],

--- a/src/fetcher.sv
+++ b/src/fetcher.sv
@@ -12,14 +12,14 @@ module fetcher #(
     input wire reset,
     
     // Execution State
-    input reg [2:0] core_state,
-    input reg [7:0] current_pc,
+    input [2:0] core_state,
+    input [7:0] current_pc,
 
     // Program Memory
     output reg mem_read_valid,
     output reg [PROGRAM_MEM_ADDR_BITS-1:0] mem_read_address,
-    input reg mem_read_ready,
-    input reg [PROGRAM_MEM_DATA_BITS-1:0] mem_read_data,
+    input mem_read_ready,
+    input [PROGRAM_MEM_DATA_BITS-1:0] mem_read_data,
 
     // Fetcher Output
     output reg [2:0] fetcher_state,

--- a/src/lsu.sv
+++ b/src/lsu.sv
@@ -11,25 +11,25 @@ module lsu (
     input wire enable, // If current block has less threads then block size, some LSUs will be inactive
 
     // State
-    input reg [2:0] core_state,
+    input [2:0] core_state,
 
     // Memory Control Sgiansl
-    input reg decoded_mem_read_enable,
-    input reg decoded_mem_write_enable,
+    input decoded_mem_read_enable,
+    input decoded_mem_write_enable,
 
     // Registers
-    input reg [7:0] rs,
-    input reg [7:0] rt,
+    input [7:0] rs,
+    input [7:0] rt,
 
     // Data Memory
     output reg mem_read_valid,
     output reg [7:0] mem_read_address,
-    input reg mem_read_ready,
-    input reg [7:0] mem_read_data,
+    input mem_read_ready,
+    input [7:0] mem_read_data,
     output reg mem_write_valid,
     output reg [7:0] mem_write_address,
     output reg [7:0] mem_write_data,
-    input reg mem_write_ready,
+    input mem_write_ready,
 
     // LSU Outputs
     output reg [1:0] lsu_state,

--- a/src/pc.sv
+++ b/src/pc.sv
@@ -16,19 +16,19 @@ module pc #(
     input wire enable, // If current block has less threads then block size, some PCs will be inactive
 
     // State
-    input reg [2:0] core_state,
+    input [2:0] core_state,
 
     // Control Signals
-    input reg [2:0] decoded_nzp,
-    input reg [DATA_MEM_DATA_BITS-1:0] decoded_immediate,
-    input reg decoded_nzp_write_enable,
-    input reg decoded_pc_mux, 
+    input [2:0] decoded_nzp,
+    input [DATA_MEM_DATA_BITS-1:0] decoded_immediate,
+    input decoded_nzp_write_enable,
+    input decoded_pc_mux, 
 
     // ALU Output - used for alu_out[2:0] to compare with NZP register
-    input reg [DATA_MEM_DATA_BITS-1:0] alu_out,
+    input [DATA_MEM_DATA_BITS-1:0] alu_out,
 
     // Current & Next PCs
-    input reg [PROGRAM_MEM_ADDR_BITS-1:0] current_pc,
+    input [PROGRAM_MEM_ADDR_BITS-1:0] current_pc,
     output reg [PROGRAM_MEM_ADDR_BITS-1:0] next_pc
 );
     reg [2:0] nzp;

--- a/src/registers.sv
+++ b/src/registers.sv
@@ -14,24 +14,24 @@ module registers #(
     input wire enable, // If current block has less threads then block size, some registers will be inactive
 
     // Kernel Execution
-    input reg [7:0] block_id,
+    input [7:0] block_id,
 
     // State
-    input reg [2:0] core_state,
+    input [2:0] core_state,
 
     // Instruction Signals
-    input reg [3:0] decoded_rd_address,
-    input reg [3:0] decoded_rs_address,
-    input reg [3:0] decoded_rt_address,
+    input [3:0] decoded_rd_address,
+    input [3:0] decoded_rs_address,
+    input [3:0] decoded_rt_address,
 
     // Control Signals
-    input reg decoded_reg_write_enable,
-    input reg [1:0] decoded_reg_input_mux,
-    input reg [DATA_BITS-1:0] decoded_immediate,
+    input decoded_reg_write_enable,
+    input [1:0] decoded_reg_input_mux,
+    input [DATA_BITS-1:0] decoded_immediate,
 
     // Thread Unit Outputs
-    input reg [DATA_BITS-1:0] alu_out,
-    input reg [DATA_BITS-1:0] lsu_out,
+    input [DATA_BITS-1:0] alu_out,
+    input [DATA_BITS-1:0] lsu_out,
 
     // Registers
     output reg [7:0] rs,

--- a/src/scheduler.sv
+++ b/src/scheduler.sv
@@ -21,17 +21,17 @@ module scheduler #(
     input wire start,
     
     // Control Signals
-    input reg decoded_mem_read_enable,
-    input reg decoded_mem_write_enable,
-    input reg decoded_ret,
+    input decoded_mem_read_enable,
+    input decoded_mem_write_enable,
+    input decoded_ret,
 
     // Memory Access State
-    input reg [2:0] fetcher_state,
-    input reg [1:0] lsu_state [THREADS_PER_BLOCK-1:0],
+    input [2:0] fetcher_state,
+    input [1:0] lsu_state [THREADS_PER_BLOCK-1:0],
 
     // Current & Next PC
     output reg [7:0] current_pc,
-    input reg [7:0] next_pc [THREADS_PER_BLOCK-1:0],
+    input [7:0] next_pc [THREADS_PER_BLOCK-1:0],
 
     // Execution State
     output reg [2:0] core_state,


### PR DESCRIPTION
Getting bunch of errors during compilation due to declaring input as reg type.

```
build/gpu.v:1014: error: Port decoded_nzp of module pc is declared as input and as a reg type.
build/gpu.v:1016: error: Port decoded_nzp_write_enable of module pc is declared as input and as a reg type.
build/gpu.v:1017: error: Port decoded_pc_mux of module pc is declared as input and as a reg type.
build/gpu.v:1235: error: Port core_state of module alu is declared as input and as a reg type.
```

Dropping `reg` from input seems to fix this issue. I am not a Verilog expert, so not sure if this is specific to the iverilog (version 11) compiler I am using or the problem with SV2V conversion. 

PR also contains some minor updates to README and Makefile
