### PR TITLE
Modify misleading comment

### DIFF
--- a/src/controller.sv
+++ b/src/controller.sv
@@ -64,6 +64,7 @@ module controller #(
 
             channel_serving_consumer = 0;
         end else begin 
+            // For each channel, we handle processing completely concurrently except for IDLE
             for (int i = 0; i < NUM_CHANNELS; i = i + 1) begin 
                 case (controller_state[i])
                     IDLE: begin

--- a/src/controller.sv
+++ b/src/controller.sv
@@ -64,7 +64,6 @@ module controller #(
 
             channel_serving_consumer = 0;
         end else begin 
-            // For each channel, we handle processing concurrently
             for (int i = 0; i < NUM_CHANNELS; i = i + 1) begin 
                 case (controller_state[i])
                     IDLE: begin


### PR DESCRIPTION
channel_serving_consumer[j] = 1 makes each channel dependent on the selection of the previous ones.
Each channel must wait for previous channels to select consumers to service because, if they didn't, then the channels wouldn't know which ones to not choose and could all select the same consumer to service.