### PR TITLE
Add waveform with iverilog simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ gds/**/*.gltf
 
 .DS_Store
 results.xml
+
+sim_build/**

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export LIBPYTHON_LOC=$(shell cocotb-config --libpython)
 test_%:
 	make compile
 	iverilog -o build/sim.vvp -s gpu -g2012 build/gpu.v
-	MODULE=test.test_$* vvp -M $$(cocotb-config --prefix)/cocotb/libs -m libcocotbvpi_icarus build/sim.vvp
+	MODULE=test.test_$* vvp -M $$(cocotb-config --prefix)/cocotb/libs -m libcocotbvpi_icarus build/sim.vvp -fst
 
 compile:
 	make compile_alu
@@ -19,7 +19,12 @@ compile:
 compile_%:
 	sv2v -w build/$*.v src/$*.sv
 
-# TODO: Get gtkwave visualizaiton
+# The gtkwave FST file -> sim_build/gpu.fst
+test.test_%: compile
+	make -f Makefile.cocotb.mk MODULE=$@
 
 show_%: %.vcd %.gtkw
 	gtkwave $^
+
+clean:
+	rm -rf build/* sim_build

--- a/Makefile.cocotb.mk
+++ b/Makefile.cocotb.mk
@@ -1,0 +1,19 @@
+# Makefile
+
+# defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+# Enable wakeform
+WAVES=1
+
+VERILOG_SOURCES += build/gpu.v
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = gpu
+
+# MODULE is the basename of the Python test file
+MODULE := test.test_matadd
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
This PR is to support Waveform output for Icarus Verilog simulator.

How to generate waveform,
``` shell
# A new target test.test_% is added. Based on the design of this project, % is matadd or matmul.
# To generate waveform for matadd test, run
$ make test.test_matadd

# The generated waveform file is sim_build/gpu.fst. Use gtkwave to open.
```

![image](https://github.com/user-attachments/assets/920bae82-5c24-4a50-8c6c-68b649449e5e)

