### PR TITLE
Add Makefile.sv to directly simulate SV files using tools like VCS

### DIFF
--- a/Makefile.sv
+++ b/Makefile.sv
@@ -1,0 +1,43 @@
+TOPLEVEL_LANG = verilog
+
+SIM ?= questa
+WAVES ?= 0
+
+COCOTB_HDL_TIMEUNIT = 1ns
+COCOTB_HDL_TIMEPRECISION = 1ns
+
+DUT      = gpu
+TOPLEVEL = $(DUT)
+MODULE   = test.test_matadd
+
+RTL_DIR = ./src
+
+# VERILOG_SOURCES += $(RTL_DIR)/alu.sv
+# VERILOG_SOURCES += $(RTL_DIR)/controller.sv
+# VERILOG_SOURCES += $(RTL_DIR)/dcr.sv
+# VERILOG_SOURCES += $(RTL_DIR)/decoder.sv
+# VERILOG_SOURCES += $(RTL_DIR)/dispatch.sv
+# VERILOG_SOURCES += $(RTL_DIR)/fetcher.sv
+# VERILOG_SOURCES += $(RTL_DIR)/lsu.sv
+# VERILOG_SOURCES += $(RTL_DIR)/pc.sv
+# VERILOG_SOURCES += $(RTL_DIR)/registers.sv
+# VERILOG_SOURCES += $(RTL_DIR)/scheduler.sv
+# VERILOG_SOURCES += $(RTL_DIR)/core.sv
+# VERILOG_SOURCES += $(RTL_DIR)/gpu.sv
+
+VERILOG_SOURCES += build/gpu.v
+COMPILE_ARGS += +define+SIM
+
+ifeq ($(SIM), questa)
+	COMPILE_ARGS += -sv
+endif
+
+ifeq ($(SIM), vcs)
+	SIM_BUILD ?= .
+	COMPILE_ARGS += -V -debug_access+r+w+nomemcbk -debug_region+cell +define+VCS
+endif
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+clean::
+	@rm -rf dump.fst $(TOPLEVEL).fst sim_build/runsim.do

--- a/test/helpers/format.py
+++ b/test/helpers/format.py
@@ -10,7 +10,7 @@ def format_register(register: int) -> str:
         return f"%blockDim"
     if register == 15:
         return f"%threadIdx"
-    
+
 def format_instruction(instruction: str) -> str:
     opcode = instruction[0:4]
     rd = format_register(int(instruction[4:8], 2))
@@ -104,6 +104,7 @@ def format_cycle(dut, cycle_id: int, thread_id: Optional[int] = None):
 
         logger.debug(f"\n+--------------------- Core {core.i.value} ---------------------+")
 
+        dir(core.core_instance)
         instruction = str(core.core_instance.instruction.value)
         for thread in core.core_instance.threads:
             if int(thread.i.value) < int(str(core.core_instance.thread_count.value), 2): # if enabled


### PR DESCRIPTION
So no need to use other tools to first convert SV to verilog.