### PR TITLE
Fix compatibility with cocotb v2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .PHONY: test compile
 
 export LIBPYTHON_LOC=$(shell cocotb-config --libpython)
+export PYGPI_PYTHON_BIN=$(shell cocotb-config --python-bin)
 
 test_%:
 	make compile
 	iverilog -o build/sim.vvp -s gpu -g2012 build/gpu.v
-	MODULE=test.test_$* vvp -M $$(cocotb-config --prefix)/cocotb/libs -m libcocotbvpi_icarus build/sim.vvp
+	COCOTB_TEST_MODULES=test.test_$* vvp -M $$(cocotb-config --lib-dir) -m libcocotbvpi_icarus build/sim.vvp
 
 compile:
 	make compile_alu

--- a/test/helpers/format.py
+++ b/test/helpers/format.py
@@ -99,17 +99,17 @@ def format_cycle(dut, cycle_id: int, thread_id: Optional[int] = None):
 
     for core in dut.cores:
         # Not exactly accurate, but good enough for now
-        if int(str(dut.thread_count.value), 2) <= core.i.value * dut.THREADS_PER_BLOCK.value:
+        if int(str(dut.thread_count.value), 2) <= int(core.i.value) * int(dut.THREADS_PER_BLOCK.value):
             continue
 
-        logger.debug(f"\n+--------------------- Core {core.i.value} ---------------------+")
+        logger.debug(f"\n+--------------------- Core {int(core.i.value)} ---------------------+")
 
         instruction = str(core.core_instance.instruction.value)
         for thread in core.core_instance.threads:
             if int(thread.i.value) < int(str(core.core_instance.thread_count.value), 2): # if enabled
-                block_idx = core.core_instance.block_id.value
-                block_dim = int(core.core_instance.THREADS_PER_BLOCK)
-                thread_idx = thread.register_instance.THREAD_ID.value
+                block_idx = int(core.core_instance.block_id.value)
+                block_dim = int(core.core_instance.THREADS_PER_BLOCK.value)
+                thread_idx = int(thread.register_instance.THREAD_ID.value)
                 idx = block_idx * block_dim + thread_idx
 
                 rs = int(str(thread.register_instance.rs.value), 2)

--- a/test/helpers/setup.py
+++ b/test/helpers/setup.py
@@ -13,7 +13,7 @@ async def setup(
     threads: int
 ):
     # Setup Clock
-    clock = Clock(dut.clk, 25, units="us")
+    clock = Clock(dut.clk, 25, unit="us")
     cocotb.start_soon(clock.start())
 
     # Reset


### PR DESCRIPTION
## Summary
- Update Makefile to use cocotb v2 API (`--lib-dir`, `COCOTB_TEST_MODULES`, `PYGPI_PYTHON_BIN`)
- Fix deprecated `units` parameter to `unit` in `Clock()`
- Convert `LogicArray` values to `int` before arithmetic operations

## Problem
The project doesn't work with cocotb v2.x due to API changes:

```
cocotb-config: error: unrecognized arguments: --prefix
PYGPI_PYTHON_BIN variable not set. Can't initialize Python interpreter!
TypeError: unsupported operand type(s) for *: 'LogicArray' and 'LogicArray'
```

## Test plan
- [x] `make test_matadd` passes
- [x] `make test_matmul` passes

Tested with cocotb v2.0.1, Python 3.13, Icarus Verilog 12.0